### PR TITLE
Some randomizer fixes

### DIFF
--- a/src/resources/randomizers/animal.txt
+++ b/src/resources/randomizers/animal.txt
@@ -279,7 +279,7 @@ giant salamander
 giant water bug
 gibbon
 Gigantopithecus
-gilmonster
+gila monster
 giraffe
 giraffe beetle
 glass frog
@@ -353,7 +353,6 @@ horse
 horsefly
 horseshoe crab
 house centipede
-house centipede
 house hippo
 housecat
 housefly
@@ -361,7 +360,6 @@ hoverfly
 howler monkey
 Humboldt squid
 hummingbird
-hummingbird hawk-moth
 hummingbird hawk-moth
 humpback whale
 Hupehsuchus
@@ -436,7 +434,7 @@ mandrill
 maned wolf
 mantis
 mantis shrimp
-mantray
+manta ray
 marabou stork
 marine iguana
 marmoset
@@ -455,7 +453,7 @@ mole
 mole crab
 mole cricket
 mole lizard
-molmola
+mola mola
 monarch butterfly
 mongoose
 monitor lizard
@@ -523,7 +521,7 @@ peacock spider
 peanut-headed lanternfly
 pelecinid wasp
 pelican
-pelicspider
+pelican spider
 penguin
 peregrine falcon
 periscope spider
@@ -569,7 +567,7 @@ pug
 pygmy hippo
 pygmy seahorse
 pygmy sperm whale
-pyjamsquid
+pyjama squid
 python
 quail
 Quetzalcoatlus
@@ -621,22 +619,22 @@ scorpionfish
 scorpionfly
 seagull
 seahorse
-seanemone
-seangel
-sebutterfly
+sea anemone
+sea angel
+sea butterfly
 secretarybird
-sehare
-selily
-selion
-sepen
-sepig
-serobin
-sescorpion
-sesnake
-sespider
-sesquirt
-seturtle
-seurchin
+sea hare
+sea lily
+sea lion
+sea pen
+sea pig
+sea robin
+sea scorpion
+sea snake
+sea spider
+sea squirt
+sea turtle
+sea urchin
 Sharovipteryx
 sheep
 shipworm

--- a/src/resources/randomizers/animal.txt
+++ b/src/resources/randomizers/animal.txt
@@ -69,7 +69,7 @@ black bear
 black grouse
 black mamba
 black widow
-Blaesospirsnail
+Blaesospira snail
 blanket octopus
 bleached coral
 blobfish

--- a/src/resources/randomizers/headgear.txt
+++ b/src/resources/randomizers/headgear.txt
@@ -1,180 +1,180 @@
 abaya
 agal
 ajkača
-aliceband
+alice band
 american fiber helmet
-anthonyeden hat
+anthony eden hat
 aqal
-arabheaddress
-archersbonnet
-asianconicalhat
-asookehat
-aviatorscap
+arab headdress
+archers bonnet
+asian conical hat
+asooke hat
+aviators cap
 balaclava
-balibuntal
-balmoralbonnet
+bali buntal
+balmoral bonnet
 bandana
-bandeauhat
+bandeau hat
 barretina
 basher
 bashlyk
 battoulah
-bearskinhat
-beaverhat
-beefeatershat
+bearskin hat
+beaver hat
+beefeaters hat
 beehive
 beret
-bergèrehat
+bergère hat
 bersagliere
 bhatgaunletopi
 bicorne
 billycock
 birdcage
 biretta
-blackcap
+black cap
 blangkon
 bloomer
-bluebonnet
+blue bonnet
 boater
 bongrace
-bonnethead
-booniehat
-bossoftheplains
-boudoircap
+bonnet head
+boonie hat
+boss of the plains
+boudoir cap
 boushiya
 bowler
 boxer
 breton
-brodrickcap
+brodrick cap
 buknuk
-bunhat
+bun hat
 burga
 busby
 bycocket
-cabbage-treehat
+cabbage-tree hat
 cabriolet
 camauro
-campaignhat
-canterburycap
-capandbells
-capcomforter
-capofmaintenance
-capeann
+campaign hat
+canterbury cap
+cap and bells
+cap comforter
+cap of maintenance
+cape ann
 capeline
 capirote
 capotain
 capote
-cappelloromano
-cartwheelhat
-casquetteorcyclingcap
+cappello romano
+cartwheel hat
+casquette or cycling cap
 castor
 caubeen
-cavalierhat
+cavalier hat
 chador
 chapeau-bras
 chaperon
 cheich
-chipbonnet
-chiphat
+chip bonnet
+chip hat
 chullo
 chupalla
 cloche
 clop
-cocklehat
-cocktailhat
+cockle hat
+cocktail hat
 coif
-cokehat
+coke hat
 colback
-combinationcap
+combination cap
 cony
-cooliehat
-coonskinhat
+coolie hat
+coonskin hat
 copintank
 cordies
-corkhat
+cork hat
 coronet
-cossackhat
-cowboyhat
-cricketcap
+cossack hat
+cowboy hat
+cricket cap
 crispine
 crown
 cucupha
-custodianhelmet
+custodian helmet
 deerstalker
-demicastorhat
+demicastor hat
 derby
 diadem
-diggerhat
+digger hat
 directoire
-divingmask
+diving mask
 do-rag
-dogonhat
-dollhat
-dollyvarden
-duncecap
+dogon hat
+doll hat
+dolly varden
+dunce cap
 dupatta
-energydome
-envelopebusby
-fan-tailhat
+energy dome
+envelope busby
+fan-tail hat
 fascinator
-featherbonnet
-featheredheaddress
+feather bonnet
+feathered headdress
 fedora
 fez
-firefightershelmet
-flatcap
+firefighters helmet
+flat cap
 flat
-flemishhood
-flyinghelmet
-foragecap
-fourwindshat
-frenchhood
-fulanihat
+flemish hood
+flying helmet
+forage cap
+fourwinds hat
+french hood
+fulani hat
 full-facedivingmask
 gablehood
 gahfiah
-gainsboroughhat
+gainsborough hat
 galero
 galician
-garbohat
+garbo hat
 gargush
 garibaldi
-garrisoncap
+garrison cap
 gasmask
 gasa
 għonnella
-gipsyhat
-glengarrybonnet
-goldenhat
-gossamerhat
-grebehat
-greeneyeshade
-gypsybonnet
-haidahat
-halfhat
-halohat
-hardeehat
-hatterraigurkha
+gipsy hat
+glengarry bonnet
+golden hat
+gossamer hat
+grebe hat
+green eyeshade
+gypsy bonnet
+haida hat
+half hat
+halo hat
+hardee hat
+hat terrai gurkha
 havalim
 headband
 headscarf
 helmet
 hennin
 hijab
-holycrownofhungary
+holy crown of hungary
 homburg
 hood
-huntinghat
-icelandictail-cap
+hunting hat
+icelandic tail-cap
 igal
-imperialcrownofindia
-imperialstatecrown
-irishwalkinghat
+imperial crown of india
+imperial state crown
+irish walking hat
 jaapi
-jeepcap
+jeep cap
 jerry
-jockeyscap
-julietcap
+jockeys cap
+juliet cap
 kalimavkion
 kalpak
 kartus
@@ -182,154 +182,154 @@ kashket
 kausia
 keffiyeh
 kepi
-kevenhuller
+keven huller
 khimar
 kippah
-kiss-me-quickhat
+kiss-me-quick hat
 klobuk
 kofia
 kokoshnik
 kolpik
 koukoulion
 kufi
-latexmask
-leghornbonnet
-leghornhat
-leopardcap
+latex mask
+leghorn bonnet
+leghorn hat
+leopard cap
 litham
 lungee
-mandarinhat
+mandarin hat
 mandily
-manillahat
+manilla hat
 mantilla
-marquishat
-maryqueenofscots
-matinéehat
-medievalhood
-merrywidowhat
+marquis hat
+mary queen of scots
+matinée hat
+medieval hood
+merry widow hat
 migbaat
 milfeh
-mingofficialheadwear
+ming official headwear
 mirliton
 mitre
 mitznefet
 moab
 mob-cap
 mokorotlo
-monmouthcap
-montenegrincap
+monmouth cap
+montenegrin cap
 montera
-mourningbonnet
-mourninghat
-mourninghood
+mourning bonnet
+mourning hat
+mourning hood
 mousquetaire
 mukut
-müllerhat
+müller hat
 mushroom
 nemes
-nightcap
+night cap
 niqab
-nónlá
-nónquaithao
-nursescap
+nón lá
+nón quai thao
+nurses cap
 ochipok
 ogal
-orthodonticfacemask
+orthodontic facemask
 pagri
 pakol
-pamelahat
+pamela hat
 panzva
-panamahat
+panama hat
 papakha
-papaltiara
-partyhat
-patrolcap
+papal tiara
+party hat
+patrol cap
 pava
-peakedcap
+peaked cap
 peci
 perak
 petasos
 pheta
-phrygiancap
+phrygian cap
 phylacteries
 pickelhaube
 pileus
-pillboxhat
-pillboxcap
+pillbox hat
+pillbox cap
 pinner
-pithhelmet
-pointyhat
-pokebonnet
+pith helmet
+pointy hat
+poke bonnet
 porkpie
-printershat
-propellerhat
-pussyhat
+printers hat
+propeller hat
+pussy hat
 qeleshe
-qingofficialheadwear
+qing official headwear
 quadricorn
 rasampagri
 ridinghood
-sailorcap
+sailor cap
 salakot
-santashat
+santas hat
 sarpech
-scrumcap
+scrum cap
 shako
 sheitel
 shmagh
-shovelhat
-showercap
+shovel hat
+shower cap
 shripech
 shtreimel
-sikhturban
+sikh turban
 skimmer
 skufia
-slouchhat
+slouch hat
 smagh
-smokingcap
+smoking cap
 snood
 sombrero
-songofficialheadwear
+song official headwear
 songkok
 souwester
-spacehelmet
+space helmet
 spodik
-squareacademiccap
-stedwardscrown
-stockingcap
-stormykromercap
-stuarthood
+square academic cap
+stedwards crown
+stocking cap
+stormy kromer cap
+stuart hood
 sudra
 sugarloaf
-swimmingcap
+swimming cap
 tagelmust
-tamoshanter
-tangofficialheadwear
+tam o shanter
+tang official headwear
 tantour
 taqiya
-tarletonhelmet
+tarleton helmet
 tiilangga
 tiara
 tinfoil
-tophat
+top hat
 topor
 toque
 tricorne
 trilby
 tudong
 turban
-umbrellahat
+umbrella hat
 ushanka
 veil
-veiledhat
+veiled hat
 visor
-warbonnet
-watermelonhelmet
-weddingveil
-welshhat
-whoopeecap
+war bonnet
+watermelon helmet
+wedding veil
+welsh hat
+whoopee cap
 wimple
 wreath
 yarmulke
 zucchetto
-zulucrown
+zulu crown

--- a/src/resources/randomizers/headgear.txt
+++ b/src/resources/randomizers/headgear.txt
@@ -8,7 +8,7 @@ aqal
 arab headdress
 archers bonnet
 asian conical hat
-asooke hat
+aso oke hat
 aviators cap
 balaclava
 bali buntal


### PR DESCRIPTION
In animal.txt, some cases of /an? / were removed (presumably to remove articles) even when part of another word, creating e.g. 'gilmonster' and 'pelicspider'. I also removed a couple duplicate entries. In headgear.txt, many entries were concatenated into one long word like 'holycrownofhungary', which can cause problems with Stable trying to parse it into tokens and getting the word breaks wrong